### PR TITLE
feat: multiple entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Kong Icon Library",
   "license": "Apache-2.0",
   "type": "module",
-  "main": "./dist/kong-icons.umd.js",
+  "main": "./dist/kong-icons.cjs.js",
   "module": "./dist/kong-icons.es.js",
   "files": [
     "dist"
@@ -14,7 +14,23 @@
   "exports": {
     ".": {
       "import": "./dist/kong-icons.es.js",
-      "require": "./dist/kong-icons.umd.js"
+      "require": "./dist/kong-icons.cjs.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./solid": {
+      "import": "./dist/kong-icons.solid.es.js",
+      "require": "./dist/kong-icons.solid.cjs.js",
+      "types": "./dist/types/components/solid/index.d.ts"
+    },
+    "./multi-color": {
+      "import": "./dist/kong-icons.multi-color.es.js",
+      "require": "./dist/kong-icons.multi-color.cjs.js",
+      "types": "./dist/types/components/multi-color/index.d.ts"
+    },
+    "./flags": {
+      "import": "./dist/kong-icons.flags.es.js",
+      "require": "./dist/kong-icons.flags.cjs.js",
+      "types": "./dist/types/components/flags/index.d.ts"
     },
     "./package.json": "./package.json",
     "./dist/*": "./dist/*"
@@ -24,7 +40,8 @@
   },
   "scripts": {
     "build": "rimraf './src/components' && yarn stylelint && yarn lint && yarn build:components",
-    "build:components": "rimraf './dist' && yarn generate && yarn typecheck && vite build && rimraf ./dist/style.css && vue-tsc -p './tsconfig.build.json' --emitDeclarationOnly && tsc-alias -p './tsconfig.build.json'",
+    "build:components": "rimraf './dist' && yarn generate && yarn typecheck && vite build && rimraf ./dist/style.css && yarn build:types",
+    "build:types": "vue-tsc -p './tsconfig.build.json' --emitDeclarationOnly && tsc-alias -p './tsconfig.build.json'",
     "build:visualize": "BUILD_VISUALIZER=true rimraf ./dist && yarn generate && vite build -m production",
     "generate": "ts-node -P './scripts/tsconfig.json' './scripts/generate.ts' && yarn fix:generated",
     "update-component-list": "ts-node -P './scripts/tsconfig.json' './scripts/component-list.ts' && yarn fix:generated",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path, { join } from 'path'
 import { visualizer } from 'rollup-plugin-visualizer'
+import { getSubdirectories } from './scripts/utilities'
 
 // Include the rollup-plugin-visualizer if the BUILD_VISUALIZER env var is set to "true"
 const buildVisualizerPlugin = process.env.BUILD_VISUALIZER
@@ -12,6 +13,20 @@ const buildVisualizerPlugin = process.env.BUILD_VISUALIZER
     gzipSize: true,
   })
   : undefined
+
+const getEntryPoints = () => {
+  // Initialize the entryPoints object with the default export already configured
+  const entryPoints = {
+    default: path.resolve(__dirname, 'src/index.ts'),
+  }
+  const componentDirectories = getSubdirectories(path.resolve('./src/components'))
+
+  for (const dir of componentDirectories) {
+    entryPoints[dir] = path.resolve(__dirname, `src/components/${dir}/index.ts`)
+  }
+
+  return entryPoints
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -36,9 +51,9 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: path.resolve(__dirname, 'src/index.ts'),
+      entry: getEntryPoints(),
       name: 'KongIcons',
-      fileName: (format) => `kong-icons.${format}.js`,
+      fileName: (format, entryName) => entryName === 'default' ? `kong-icons.${format}.js` : `kong-icons.${entryName}.${format}.js`,
     },
     emptyOutDir: true,
     minify: true,


### PR DESCRIPTION
Process and export multiple entry files to allow for importing icons either from the root, or from one of the directories `solid`, `multi-color`, or `flags`