### PR TITLE
feat(*): rename tag prop to as

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,19 @@ As a convenience, you may pass the size as a `number`, e.g. `24` or as a string 
 
 When utilizing a `string`, do not pass any units along with the value.
 
-#### `tag`
+#### `as`
 
 - type: `String`
 - required: `false`
 - default: `'span'`
 
 The HTML tag to use in place of the default wrapper `<span>` tag.
+
+##### Example
+
+```html
+<CloseIcon as="button" />
+```
 
 ## Contributing & Local Development
 

--- a/src/__template__/ComponentTemplate.vue
+++ b/src/__template__/ComponentTemplate.vue
@@ -51,7 +51,7 @@ const props = defineProps({
     },
   },
   /** The HTML tag to utilize for the icon's wrapper element. Defaults to `span` */
-  tag: {
+  as: {
     type: String,
     required: false,
     default: 'span',
@@ -93,7 +93,7 @@ const rootElementStyles = computed((): Record<string, string> => ({
 
 <template>
   <component
-    :is="tag"
+    :is="as"
     :aria-hidden="decorative ? 'true' : undefined"
     class="kui-icon {%%KONG_COMPONENT_ICON_CLASS%%}"
     data-testid="kui-icon-wrapper-{%%KONG_COMPONENT_ICON_CLASS%%}"

--- a/src/tests/all-components.spec.ts
+++ b/src/tests/all-components.spec.ts
@@ -13,7 +13,7 @@ for (const [componentName, component] of Object.entries(importedComponents)) {
           display: 'inline-flex',
           decorative: false,
           size: 32,
-          tag: 'span',
+          as: 'span',
         },
       })
 

--- a/src/tests/generated-component.spec.ts
+++ b/src/tests/generated-component.spec.ts
@@ -228,25 +228,27 @@ describe(`Icon Components (randomly testing '${component.__name}.vue')`, () => {
       })
     })
 
-    describe('tag', () => {
-      it('defaults to a `span` tag when the tag prop is not provided', () => {
+    describe('as', () => {
+      it('defaults to a `span` tag when the as prop is not provided', () => {
         const wrapper = mount(component)
         const iconWrapper = wrapper.find('span.kui-icon')
 
         expect(iconWrapper.exists()).toBe(true)
       })
 
-      it('customizes the HTML wrapper element if the tag prop is provided', () => {
-        const tag = 'section'
+      it('customizes the HTML wrapper element if the as prop is provided', () => {
+        const as = 'button'
         const wrapper = mount(component, {
           props: {
-            tag,
+            as,
           },
         })
-        const spanWrapper = wrapper.find('span.kui-icon')
-        const iconWrapper = wrapper.find(`${tag}.kui-icon`)
 
+        // Look for default element
+        const spanWrapper = wrapper.find('span.kui-icon')
         expect(spanWrapper.exists()).toBe(false)
+
+        const iconWrapper = wrapper.find(`${as}.kui-icon`)
         expect(iconWrapper.exists()).toBe(true)
       })
     })


### PR DESCRIPTION
# Summary

Renames the `tag` prop to `as`

## Example

```html
<CloseIcon as="button" />
```

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
