### PR TITLE
fix(sandbox): add debounce and persist route query params

### DIFF
--- a/sandbox/components/PageHeader.vue
+++ b/sandbox/components/PageHeader.vue
@@ -47,7 +47,7 @@ const handleQueryUpdate = debounce((searchQuery: string) => {
   } else {
     router.push({ name: 'home' })
   }
-}, 1000)
+}, 500)
 
 watch(query, (searchQuery: string) => {
   handleQueryUpdate(searchQuery)
@@ -56,7 +56,7 @@ watch(query, (searchQuery: string) => {
 onMounted(() => {
   if (route.query.q) {
     query.value = route.query.q as string
-    emit('search', route.query.q)
+    emit('search', query.value)
   }
 })
 </script>

--- a/sandbox/components/PageHeader.vue
+++ b/sandbox/components/PageHeader.vue
@@ -28,6 +28,7 @@
 import { onMounted, ref, watch } from 'vue'
 import { ExternalLinkIcon } from '@/components'
 import { useRoute, useRouter } from 'vue-router'
+import { debounce } from '../utilities'
 
 const route = useRoute()
 const router = useRouter()
@@ -38,21 +39,24 @@ const emit = defineEmits<{
 
 const query = ref('')
 
-watch(query, (searchQuery: string) => {
+const handleQueryUpdate = debounce((searchQuery: string) => {
   emit('search', searchQuery)
 
   if (searchQuery) {
-    if (searchQuery !== route.query.search) {
-      router.push({ name: 'home', query: { search: searchQuery } })
-    }
+    router.push({ name: 'home', query: { q: searchQuery } })
   } else {
     router.push({ name: 'home' })
   }
+}, 1000)
+
+watch(query, (searchQuery: string) => {
+  handleQueryUpdate(searchQuery)
 }, { immediate: true })
 
 onMounted(() => {
-  if (route.query.search) {
-    query.value = route.query.search as string
+  if (route.query.q) {
+    query.value = route.query.q as string
+    emit('search', route.query.q)
   }
 })
 </script>

--- a/sandbox/utilities/index.ts
+++ b/sandbox/utilities/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns a function, that, as long as it continues to be invoked, will not be triggered. The initial function will be called after the debounced function stops being called for a certain number of milliseconds.
+ *
+ * @param initialFunction Initial function to debounce
+ * @param delay Time to wait for recurring bounces
+ * @returns the debounced function.
+ */
+export function debounce(initialFunction: (...args: any) => any, delay: number): (...args: any) => void {
+  // Store timeout ID outside the returned function.
+  let timeoutId: number
+
+  return (...args) => {
+    // If the debounced function was already invoked before, this will cancel the earlier timeout; thus, its callback will not be invoked.
+    clearTimeout(timeoutId)
+
+    // Starts a new timer which will call the initial function after the specified wait time unless the debounced function is called again.
+    timeoutId = window?.setTimeout(() => {
+      initialFunction(...args)
+    }, delay)
+  }
+}


### PR DESCRIPTION
# Summary

Fixes the following:
1. Refreshing the page with the search query string present does not persist the query string in the URL
2. Rename the search query string to q
3. Add a debounce function for the search so that it waits for the user to stop typing before modifying the query string

## PR Checklist

* [ ] Does not introduce dependencies
* [ ] **Functional:** all changes do not break existing APIs and if so, bump major version.
* [ ] **Tests pass:** check the output of yarn test
* [ ] **Naming:** the files and the method and prop variables use the same naming conventions as other Kongponents
* [ ] **Framework style:** abides by the essential rules in Vue's style guide
* [ ] **Cleanliness:** does not have formatting issues, unused code (e.g., console.logs, debugger), or leftover comments
* [ ] **Docs:** includes a technically accurate README, uses JSDOC where appropriate
