### PR TITLE
fix: fix escape map and share it across function calls

### DIFF
--- a/src/__template__/ComponentTemplate.vue
+++ b/src/__template__/ComponentTemplate.vue
@@ -130,16 +130,15 @@ const prefixSvgIdsInString = (svgString: string): string => {
   return processedSvgString
 }
 
+const htmlEntities: { [key: string]: string } = {
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+  '&': '&amp;',
+}
 const escapeHtml = (str: string) => {
-  const htmlEntities: { [key: string]: string } = {
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#039;',
-    '`': '&#039;',
-  }
-
-  return str.replace(/[<>"'`]/g, (match) => htmlEntities[match])
+  return str.replace(/[<>"'&]/g, (match) => htmlEntities[match])
 }
 
 // The `svgOriginalContent` template string will be replaced with the SVG innerHTML in the generate script.


### PR DESCRIPTION
# Summary

`` ` `` should be `&` and we can move the map out of `escapeHtml`.