### PR TITLE
ci: skip steps from forks if no token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,14 +23,16 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
     steps:
       - name: Remove preview consumption comment
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'pull_request' && env.GITHUB_TOKEN != '' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr_preview_consumption
           delete: true
-          GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -96,7 +98,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Provide preview link info
-        if: ${{ steps.package-preview.outputs.npm_instructions != '' }}
+        if: ${{ steps.package-preview.outputs.npm_instructions != '' && env.GITHUB_TOKEN != '' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr_preview_consumption
@@ -108,4 +110,4 @@ jobs:
              ```sh
              ${{ steps.package-preview.outputs.npm_instructions }}
              ```
-          GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary

Skip CI steps that require secrets when PR is opened from a fork
