### PR TITLE
chore: add Harden Runner to all workflows

### DIFF
--- a/.github/workflows/cleanup-preview-packages.yaml
+++ b/.github/workflows/cleanup-preview-packages.yaml
@@ -18,6 +18,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout Source Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -8,6 +8,10 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -30,6 +30,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -10,6 +10,10 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Checkout Source Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,10 @@ jobs:
         - run-tests
       runs-on: ubuntu-latest
       steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+          with:
+            egress-policy: audit
         - name: Checkout
           uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
           with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.KONGPONENTS_BOT_PAT }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLIC_PUBLISH }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
       - name: Remove preview consumption comment
         if: ${{ github.event_name == 'pull_request' && env.GITHUB_TOKEN != '' }}
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1


### PR DESCRIPTION
This PR adds the Step Security Harden Runner step to all GitHub Actions workflows.