### PR TITLE
fix: allow css custom properties for size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ docs/.vitepress/.temp
 docs/.vitepress/.cache
 docs/.vitepress/cache
 docs/.vitepress/dist
+
+.claude/

--- a/src/__template__/ComponentTemplate.vue
+++ b/src/__template__/ComponentTemplate.vue
@@ -34,6 +34,11 @@ const props = defineProps({
     required: false,
     default: KUI_ICON_SIZE_50, // if setting to the imported const fails, just pass a number of 24 as the default.
     validator: (sizeValue: number | string): boolean => {
+      // Allow CSS custom-property expressions, e.g. var(--kui-icon-size-50, 24px)
+      if (typeof sizeValue === 'string' && /^\s*var\(\s*--[\w-]+\s*(?:,[^)]*)?\)\s*$/.test(sizeValue)) {
+        return true
+      }
+
       if (typeof sizeValue === 'number' && sizeValue > 0) {
         return true
       }
@@ -67,7 +72,15 @@ const props = defineProps({
   },
 })
 
+/** Returns true if the given value is a CSS `var()` custom-property expression, e.g. `var(--kui-icon-size-50, 24px)` */
+const isCssVar = (value: unknown): value is string => typeof value === 'string' && /^\s*var\(\s*--[\w-]+\s*(?:,[^)]*)?\)\s*$/.test(value)
+
 const iconSize = computed((): string => {
+  // If props.size is a CSS variable expression, return it as-is
+  if (isCssVar(props.size)) {
+    return props.size as string
+  }
+
   // If props.size is a number, ensure it's greater than zero
   if (typeof props.size === 'number' && props.size > 0) {
     return `${props.size}px`

--- a/src/tests/generated-component.spec.ts
+++ b/src/tests/generated-component.spec.ts
@@ -244,6 +244,38 @@ for (const [componentName, IconComponent] of Object.entries(importedComponents))
           expect(consoleSpy).toHaveBeenCalledOnce()
           consoleSpy.mockReset()
         })
+
+        it('accepts a CSS var() custom property string', () => {
+          const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => null)
+          const size = 'var(--kui-icon-size-50, 24px)'
+
+          const wrapper = mount(IconComponent, {
+            props: {
+              size,
+            },
+          })
+
+          expect(consoleSpy).not.toHaveBeenCalled()
+          consoleSpy.mockReset()
+
+          const iconWrapper = wrapper.find('.kui-icon').element as HTMLElement
+          expect(iconWrapper.style.width).toBe(size)
+          expect(iconWrapper.style.height).toBe(size)
+        })
+
+        it('console.warns if the size prop is an unsupported CSS function value', () => {
+          const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => null)
+          const size = 'calc(100% - 4px)'
+
+          mount(IconComponent, {
+            props: {
+              size,
+            },
+          })
+
+          expect(consoleSpy).toHaveBeenCalledOnce()
+          consoleSpy.mockReset()
+        })
       })
 
       describe('as', () => {


### PR DESCRIPTION
# Summary

Allow utilizing CSS Custom Properties as `size` prop values.

```vue
<IconPlus :size="`var(--kui-icon-size-50, ${KUI_ICON_SIZE_50})`" />
```